### PR TITLE
Add Python tile renderer example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -19,4 +19,7 @@ Then run the script:
 python3 examples/tile_renderer_demo.py
 ```
 
+When testing in a headless environment set `SDL_VIDEODRIVER=dummy`. The demo
+detects this and quits automatically after a couple of seconds.
+
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,22 @@
+# Examples
+
+This directory contains small scripts demonstrating some of DevilutionX's subsystems.
+
+- `tile_renderer_demo.py` – showcases simple isometric tile rendering and a
+  movable player using Pygame.
+
+## Requirements
+
+The demo relies on the `pygame` package. Install it with:
+
+```bash
+pip install pygame
+```
+
+Then run the script:
+
+```bash
+python3 examples/tile_renderer_demo.py
+```
+
+

--- a/examples/tile_renderer_demo.py
+++ b/examples/tile_renderer_demo.py
@@ -84,17 +84,25 @@ class TileRenderer:
 
 class Player:
     def __init__(self, x, y):
-        self.x = x
-        self.y = y
+        self.x = float(x)
+        self.y = float(y)
         self.frames = create_player_frames()
         self.frame = 0
+        self.anim_time = 0.0
 
-    def move(self, dx, dy):
+    def update(self, dx, dy, dt):
+        """Move the player smoothly and advance animation when walking."""
+        speed = 3.0  # tiles per second
+        move = speed * dt
         old_x, old_y = self.x, self.y
-        self.x = max(0, min(MAP_WIDTH - 1, self.x + dx))
-        self.y = max(0, min(MAP_HEIGHT - 1, self.y + dy))
-        if (self.x, self.y) != (old_x, old_y):
-            self.frame = (self.frame + 1) % len(self.frames)
+        self.x = max(0, min(MAP_WIDTH - 1, self.x + dx * move))
+        self.y = max(0, min(MAP_HEIGHT - 1, self.y + dy * move))
+
+        if dx or dy:
+            self.anim_time += dt
+            if self.anim_time >= 0.15:
+                self.anim_time = 0.0
+                self.frame = (self.frame + 1) % len(self.frames)
 
     def draw(self, screen, origin):
         sx = (self.x - self.y) * (TILE_WIDTH // 2) + origin[0] - PLAYER_WIDTH // 2
@@ -115,28 +123,20 @@ def main():
 
     running = True
     while running:
+        dt = clock.tick(60) / 1000.0
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 running = False
 
         keys = pygame.key.get_pressed()
-        dx = dy = 0
-        if keys[pygame.K_UP]:
-            dy = -1
-        elif keys[pygame.K_DOWN]:
-            dy = 1
-        if keys[pygame.K_LEFT]:
-            dx = -1
-        elif keys[pygame.K_RIGHT]:
-            dx = 1
-        if dx or dy:
-            player.move(dx, dy)
+        dx = keys[pygame.K_RIGHT] - keys[pygame.K_LEFT]
+        dy = keys[pygame.K_DOWN] - keys[pygame.K_UP]
+        player.update(dx, dy, dt)
 
         screen.fill((0, 0, 0))
         renderer.draw_map(grid)
         player.draw(screen, origin)
         pygame.display.flip()
-        clock.tick(60)
 
     pygame.quit()
 

--- a/examples/tile_renderer_demo.py
+++ b/examples/tile_renderer_demo.py
@@ -86,21 +86,30 @@ class Player:
     def __init__(self, x, y):
         self.x = float(x)
         self.y = float(y)
+        self.vx = 0.0
+        self.vy = 0.0
         self.frames = create_player_frames()
         self.frame = 0
         self.anim_time = 0.0
 
     def update(self, dx, dy, dt):
         """Move the player smoothly and advance animation when walking."""
-        speed = 3.0  # tiles per second
-        move = speed * dt
-        old_x, old_y = self.x, self.y
-        self.x = max(0, min(MAP_WIDTH - 1, self.x + dx * move))
-        self.y = max(0, min(MAP_HEIGHT - 1, self.y + dy * move))
+        speed = 2.0  # tiles per second (slower movement)
 
-        if dx or dy:
+        target_vx = dx * speed
+        target_vy = dy * speed
+        smooth = min(1.0, 10.0 * dt)
+        self.vx += (target_vx - self.vx) * smooth
+        self.vy += (target_vy - self.vy) * smooth
+
+        self.x += self.vx * dt
+        self.y += self.vy * dt
+        self.x = max(0, min(MAP_WIDTH - 1, self.x))
+        self.y = max(0, min(MAP_HEIGHT - 1, self.y))
+
+        if abs(self.vx) > 0.01 or abs(self.vy) > 0.01:
             self.anim_time += dt
-            if self.anim_time >= 0.15:
+            if self.anim_time >= 0.2:
                 self.anim_time = 0.0
                 self.frame = (self.frame + 1) % len(self.frames)
 

--- a/examples/tile_renderer_demo.py
+++ b/examples/tile_renderer_demo.py
@@ -8,8 +8,9 @@ TILE_HEIGHT = 32
 MAP_WIDTH = 10
 MAP_HEIGHT = 10
 
-# Simple player sprite size
-PLAYER_RADIUS = 12
+# Player sprite size
+PLAYER_WIDTH = 28
+PLAYER_HEIGHT = 40
 
 # Colors for a few tile types
 TILE_COLORS = [
@@ -41,6 +42,32 @@ def random_map():
     return [[random.randrange(len(TILE_COLORS)) for _ in range(MAP_WIDTH)] for _ in range(MAP_HEIGHT)]
 
 
+def create_player_frames():
+    """Create a very simple male character with two walking frames."""
+    skin_color = (210, 160, 120)
+    shirt_color = random.choice([(40, 80, 180), (180, 60, 60), (60, 140, 60)])
+    pants_color = random.choice([(30, 30, 100), (50, 50, 50), (20, 60, 120)])
+
+    frames = []
+    for step in range(2):
+        surf = pygame.Surface((PLAYER_WIDTH, PLAYER_HEIGHT), pygame.SRCALPHA)
+        head_center = (PLAYER_WIDTH // 2, 6)
+        pygame.draw.circle(surf, skin_color, head_center, 5)
+        pygame.draw.rect(surf, shirt_color, (PLAYER_WIDTH // 2 - 4, 12, 8, 10))
+        arm_y = 14
+        pygame.draw.rect(surf, shirt_color, (PLAYER_WIDTH // 2 - 8, arm_y, 4, 8))
+        pygame.draw.rect(surf, shirt_color, (PLAYER_WIDTH // 2 + 4, arm_y, 4, 8))
+        leg_y = 22
+        if step == 0:
+            pygame.draw.rect(surf, pants_color, (PLAYER_WIDTH // 2 - 5, leg_y, 4, 12))
+            pygame.draw.rect(surf, pants_color, (PLAYER_WIDTH // 2 + 1, leg_y, 4, 12))
+        else:
+            pygame.draw.rect(surf, pants_color, (PLAYER_WIDTH // 2 - 6, leg_y, 4, 12))
+            pygame.draw.rect(surf, pants_color, (PLAYER_WIDTH // 2 + 2, leg_y, 4, 12))
+        frames.append(surf)
+    return frames
+
+
 class TileRenderer:
     def __init__(self, screen, tiles, origin):
         self.screen = screen
@@ -59,18 +86,20 @@ class Player:
     def __init__(self, x, y):
         self.x = x
         self.y = y
-        size = PLAYER_RADIUS * 2
-        self.surface = pygame.Surface((size, size), pygame.SRCALPHA)
-        pygame.draw.circle(self.surface, (255, 50, 50), (PLAYER_RADIUS, PLAYER_RADIUS), PLAYER_RADIUS)
+        self.frames = create_player_frames()
+        self.frame = 0
 
     def move(self, dx, dy):
+        old_x, old_y = self.x, self.y
         self.x = max(0, min(MAP_WIDTH - 1, self.x + dx))
         self.y = max(0, min(MAP_HEIGHT - 1, self.y + dy))
+        if (self.x, self.y) != (old_x, old_y):
+            self.frame = (self.frame + 1) % len(self.frames)
 
     def draw(self, screen, origin):
-        sx = (self.x - self.y) * (TILE_WIDTH // 2) + origin[0]
-        sy = (self.x + self.y) * (TILE_HEIGHT // 2) + origin[1] - PLAYER_RADIUS
-        screen.blit(self.surface, (sx, sy))
+        sx = (self.x - self.y) * (TILE_WIDTH // 2) + origin[0] - PLAYER_WIDTH // 2
+        sy = (self.x + self.y) * (TILE_HEIGHT // 2) + origin[1] - PLAYER_HEIGHT
+        screen.blit(self.frames[self.frame], (sx, sy))
 
 
 def main():
@@ -89,15 +118,19 @@ def main():
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 running = False
-            elif event.type == pygame.KEYDOWN:
-                if event.key == pygame.K_UP:
-                    player.move(0, -1)
-                elif event.key == pygame.K_DOWN:
-                    player.move(0, 1)
-                elif event.key == pygame.K_LEFT:
-                    player.move(-1, 0)
-                elif event.key == pygame.K_RIGHT:
-                    player.move(1, 0)
+
+        keys = pygame.key.get_pressed()
+        dx = dy = 0
+        if keys[pygame.K_UP]:
+            dy = -1
+        elif keys[pygame.K_DOWN]:
+            dy = 1
+        if keys[pygame.K_LEFT]:
+            dx = -1
+        elif keys[pygame.K_RIGHT]:
+            dx = 1
+        if dx or dy:
+            player.move(dx, dy)
 
         screen.fill((0, 0, 0))
         renderer.draw_map(grid)

--- a/examples/tile_renderer_demo.py
+++ b/examples/tile_renderer_demo.py
@@ -205,8 +205,21 @@ def main():
                 running = False
 
         keys = pygame.key.get_pressed()
-        dx = keys[pygame.K_RIGHT] - keys[pygame.K_LEFT]
-        dy = keys[pygame.K_DOWN] - keys[pygame.K_UP]
+        dx = 0
+        dy = 0
+        if keys[pygame.K_UP]:
+            dx -= 1
+            dy -= 1
+        if keys[pygame.K_DOWN]:
+            dx += 1
+            dy += 1
+        if keys[pygame.K_LEFT]:
+            dx -= 1
+            dy += 1
+        if keys[pygame.K_RIGHT]:
+            dx += 1
+            dy -= 1
+
         player.update(dx, dy, dt, blocked)
 
         screen.fill((0, 0, 0))

--- a/examples/tile_renderer_demo.py
+++ b/examples/tile_renderer_demo.py
@@ -41,12 +41,16 @@ def create_obstacle_surfaces():
 
 
 def random_obstacles(surfaces, count=12):
-    """Create a list of obstacles and a set of blocked tiles."""
+    """Create a list of obstacles and a set of blocked tiles.
+
+    Obstacles are kept away from the map edges so they never appear to
+    spill outside the board when drawn.
+    """
     obstacles = []
     blocked = set()
     while len(obstacles) < count:
-        x = random.randint(0, MAP_WIDTH - 1)
-        y = random.randint(0, MAP_HEIGHT - 1)
+        x = random.randint(1, MAP_WIDTH - 2)
+        y = random.randint(1, MAP_HEIGHT - 2)
         if (x, y) in blocked or (x == MAP_WIDTH // 2 and y == MAP_HEIGHT // 2):
             continue
         kind = random.choice(list(surfaces.keys()))
@@ -160,12 +164,15 @@ class Player:
         new_x = self.x + self.vx * dt
         new_y = self.y + self.vy * dt
 
-        if (round(new_x), round(self.y)) not in blocked:
+        target_x = round(new_x)
+        target_y = round(new_y)
+
+        if 0 <= target_x < MAP_WIDTH and (target_x, round(self.y)) not in blocked:
             self.x = new_x
         else:
             self.vx = 0.0
 
-        if (round(self.x), round(new_y)) not in blocked:
+        if 0 <= target_y < MAP_HEIGHT and (round(self.x), target_y) not in blocked:
             self.y = new_y
         else:
             self.vy = 0.0

--- a/examples/tile_renderer_demo.py
+++ b/examples/tile_renderer_demo.py
@@ -3,6 +3,7 @@
 import pygame
 import random
 import math
+import os
 
 TILE_WIDTH = 64
 TILE_HEIGHT = 32
@@ -189,6 +190,9 @@ def main():
     screen = pygame.display.set_mode((800, 600))
     clock = pygame.time.Clock()
 
+    headless = os.environ.get("SDL_VIDEODRIVER") == "dummy"
+    elapsed = 0.0
+
     tiles = create_tile_surfaces()
     obstacle_surfaces = create_obstacle_surfaces()
     grid = random_map()
@@ -200,6 +204,9 @@ def main():
     running = True
     while running:
         dt = clock.tick(60) / 1000.0
+        elapsed += dt
+        if headless and elapsed >= 2.0:
+            break
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 running = False

--- a/examples/tile_renderer_demo.py
+++ b/examples/tile_renderer_demo.py
@@ -2,6 +2,7 @@
 
 import pygame
 import random
+import math
 
 TILE_WIDTH = 64
 TILE_HEIGHT = 32
@@ -205,20 +206,24 @@ def main():
                 running = False
 
         keys = pygame.key.get_pressed()
-        dx = 0
-        dy = 0
+        sx = 0
+        sy = 0
         if keys[pygame.K_UP]:
-            dx -= 1
-            dy -= 1
+            sy -= 1
         if keys[pygame.K_DOWN]:
-            dx += 1
-            dy += 1
+            sy += 1
         if keys[pygame.K_LEFT]:
-            dx -= 1
-            dy += 1
+            sx -= 1
         if keys[pygame.K_RIGHT]:
-            dx += 1
-            dy -= 1
+            sx += 1
+
+        if sx != 0 or sy != 0:
+            length = math.hypot(sx, sy)
+            sx /= length
+            sy /= length
+
+        dx = (sx + sy) / 2
+        dy = (sy - sx) / 2
 
         player.update(dx, dy, dt, blocked)
 

--- a/examples/tile_renderer_demo.py
+++ b/examples/tile_renderer_demo.py
@@ -1,0 +1,79 @@
+"""Simple demo of isometric tile rendering using Pygame."""
+
+import pygame
+import random
+
+TILE_WIDTH = 64
+TILE_HEIGHT = 32
+MAP_WIDTH = 10
+MAP_HEIGHT = 10
+
+# Colors for a few tile types
+TILE_COLORS = [
+    (110, 170, 70),  # grass
+    (194, 194, 194), # stone
+    (120, 70, 20),   # dirt
+    (0, 120, 160),   # water
+]
+
+
+def create_tile_surfaces():
+    """Return a surface for each tile color shaped as an isometric diamond."""
+    tiles = []
+    for color in TILE_COLORS:
+        surf = pygame.Surface((TILE_WIDTH, TILE_HEIGHT), pygame.SRCALPHA)
+        # Draw diamond shape
+        points = [
+            (TILE_WIDTH // 2, 0),
+            (TILE_WIDTH - 1, TILE_HEIGHT // 2),
+            (TILE_WIDTH // 2, TILE_HEIGHT - 1),
+            (0, TILE_HEIGHT // 2),
+        ]
+        pygame.draw.polygon(surf, color, points)
+        tiles.append(surf)
+    return tiles
+
+
+def random_map():
+    return [[random.randrange(len(TILE_COLORS)) for _ in range(MAP_WIDTH)] for _ in range(MAP_HEIGHT)]
+
+
+class TileRenderer:
+    def __init__(self, screen, tiles, origin):
+        self.screen = screen
+        self.tiles = tiles
+        self.origin_x, self.origin_y = origin
+
+    def draw_map(self, grid):
+        for y, row in enumerate(grid):
+            for x, tile in enumerate(row):
+                sx = (x - y) * (TILE_WIDTH // 2) + self.origin_x
+                sy = (x + y) * (TILE_HEIGHT // 2) + self.origin_y
+                self.screen.blit(self.tiles[tile], (sx, sy))
+
+
+def main():
+    pygame.init()
+    screen = pygame.display.set_mode((800, 600))
+    clock = pygame.time.Clock()
+
+    tiles = create_tile_surfaces()
+    grid = random_map()
+    renderer = TileRenderer(screen, tiles, origin=(400, 100))
+
+    running = True
+    while running:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                running = False
+
+        screen.fill((0, 0, 0))
+        renderer.draw_map(grid)
+        pygame.display.flip()
+        clock.tick(60)
+
+    pygame.quit()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tile_renderer_demo.py
+++ b/examples/tile_renderer_demo.py
@@ -21,6 +21,38 @@ TILE_COLORS = [
 ]
 
 
+def create_obstacle_surfaces():
+    """Return surfaces for tree and rock obstacles."""
+    surfaces = {}
+    # Tree: trunk with green canopy
+    tree = pygame.Surface((32, 48), pygame.SRCALPHA)
+    pygame.draw.rect(tree, (100, 60, 20), (14, 28, 4, 12))
+    pygame.draw.circle(tree, (30, 140, 30), (16, 20), 12)
+    surfaces["tree"] = tree
+
+    # Rock: small gray boulder
+    rock = pygame.Surface((32, 24), pygame.SRCALPHA)
+    pygame.draw.polygon(rock, (120, 120, 120), [(4, 20), (16, 4), (28, 20)])
+    pygame.draw.polygon(rock, (160, 160, 160), [(6, 18), (16, 8), (26, 18)])
+    surfaces["rock"] = rock
+    return surfaces
+
+
+def random_obstacles(surfaces, count=12):
+    """Create a list of obstacles and a set of blocked tiles."""
+    obstacles = []
+    blocked = set()
+    while len(obstacles) < count:
+        x = random.randint(0, MAP_WIDTH - 1)
+        y = random.randint(0, MAP_HEIGHT - 1)
+        if (x, y) in blocked or (x == MAP_WIDTH // 2 and y == MAP_HEIGHT // 2):
+            continue
+        kind = random.choice(list(surfaces.keys()))
+        obstacles.append({"x": x, "y": y, "kind": kind})
+        blocked.add((x, y))
+    return obstacles, blocked
+
+
 def create_tile_surfaces():
     """Return a surface for each tile color shaped as an isometric diamond."""
     tiles = []
@@ -81,6 +113,13 @@ class TileRenderer:
                 sy = (x + y) * (TILE_HEIGHT // 2) + self.origin_y
                 self.screen.blit(self.tiles[tile], (sx, sy))
 
+    def draw_obstacles(self, obstacles, surfaces):
+        for ob in obstacles:
+            surf = surfaces[ob["kind"]]
+            sx = (ob["x"] - ob["y"]) * (TILE_WIDTH // 2) + self.origin_x - surf.get_width() // 2
+            sy = (ob["x"] + ob["y"]) * (TILE_HEIGHT // 2) + self.origin_y - surf.get_height()
+            self.screen.blit(surf, (sx, sy))
+
 
 class Player:
     def __init__(self, x, y):
@@ -92,8 +131,8 @@ class Player:
         self.frame = 0
         self.anim_time = 0.0
 
-    def update(self, dx, dy, dt):
-        """Move the player smoothly and advance animation when walking."""
+    def update(self, dx, dy, dt, blocked):
+        """Move the player smoothly with basic collision handling."""
         speed = 2.0  # tiles per second (slower movement)
 
         target_vx = dx * speed
@@ -102,8 +141,19 @@ class Player:
         self.vx += (target_vx - self.vx) * smooth
         self.vy += (target_vy - self.vy) * smooth
 
-        self.x += self.vx * dt
-        self.y += self.vy * dt
+        new_x = self.x + self.vx * dt
+        new_y = self.y + self.vy * dt
+
+        if (round(new_x), round(self.y)) not in blocked:
+            self.x = new_x
+        else:
+            self.vx = 0.0
+
+        if (round(self.x), round(new_y)) not in blocked:
+            self.y = new_y
+        else:
+            self.vy = 0.0
+
         self.x = max(0, min(MAP_WIDTH - 1, self.x))
         self.y = max(0, min(MAP_HEIGHT - 1, self.y))
 
@@ -125,7 +175,9 @@ def main():
     clock = pygame.time.Clock()
 
     tiles = create_tile_surfaces()
+    obstacle_surfaces = create_obstacle_surfaces()
     grid = random_map()
+    obstacles, blocked = random_obstacles(obstacle_surfaces)
     origin = (400, 100)
     renderer = TileRenderer(screen, tiles, origin=origin)
     player = Player(MAP_WIDTH // 2, MAP_HEIGHT // 2)
@@ -140,10 +192,11 @@ def main():
         keys = pygame.key.get_pressed()
         dx = keys[pygame.K_RIGHT] - keys[pygame.K_LEFT]
         dy = keys[pygame.K_DOWN] - keys[pygame.K_UP]
-        player.update(dx, dy, dt)
+        player.update(dx, dy, dt, blocked)
 
         screen.fill((0, 0, 0))
         renderer.draw_map(grid)
+        renderer.draw_obstacles(obstacles, obstacle_surfaces)
         player.draw(screen, origin)
         pygame.display.flip()
 

--- a/examples/tile_renderer_demo.py
+++ b/examples/tile_renderer_demo.py
@@ -148,14 +148,13 @@ class Player:
         self.anim_time = 0.0
 
     def update(self, dx, dy, dt, blocked):
-        """Move the player smoothly with basic collision handling."""
-        speed = 2.0  # tiles per second (slower movement)
+        """Move the player with basic collision handling."""
+        speed = 2.0  # tiles per second
 
-        target_vx = dx * speed
-        target_vy = dy * speed
-        smooth = min(1.0, 10.0 * dt)
-        self.vx += (target_vx - self.vx) * smooth
-        self.vy += (target_vy - self.vy) * smooth
+        # Apply velocity directly so movement is responsive and all
+        # tiles remain reachable even near the map edges.
+        self.vx = dx * speed
+        self.vy = dy * speed
 
         new_x = self.x + self.vx * dt
         new_y = self.y + self.vy * dt
@@ -206,24 +205,19 @@ def main():
                 running = False
 
         keys = pygame.key.get_pressed()
-        sx = 0
-        sy = 0
-        if keys[pygame.K_UP]:
-            sy -= 1
-        if keys[pygame.K_DOWN]:
-            sy += 1
-        if keys[pygame.K_LEFT]:
-            sx -= 1
-        if keys[pygame.K_RIGHT]:
-            sx += 1
+        sx = keys[pygame.K_RIGHT] - keys[pygame.K_LEFT]
+        sy = keys[pygame.K_DOWN] - keys[pygame.K_UP]
 
-        if sx != 0 or sy != 0:
-            length = math.hypot(sx, sy)
-            sx /= length
-            sy /= length
-
+        # Convert the screen direction to board space. Rightward motion on
+        # screen corresponds to increasing the board X while decreasing Y.
         dx = (sx + sy) / 2
         dy = (sy - sx) / 2
+
+        # Normalize so diagonal movement isn't faster than cardinal.
+        if dx != 0 or dy != 0:
+            length = math.hypot(dx, dy)
+            dx /= length
+            dy /= length
 
         player.update(dx, dy, dt, blocked)
 

--- a/examples/tile_renderer_demo.py
+++ b/examples/tile_renderer_demo.py
@@ -8,6 +8,9 @@ TILE_HEIGHT = 32
 MAP_WIDTH = 10
 MAP_HEIGHT = 10
 
+# Simple player sprite size
+PLAYER_RADIUS = 12
+
 # Colors for a few tile types
 TILE_COLORS = [
     (110, 170, 70),  # grass
@@ -52,6 +55,24 @@ class TileRenderer:
                 self.screen.blit(self.tiles[tile], (sx, sy))
 
 
+class Player:
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+        size = PLAYER_RADIUS * 2
+        self.surface = pygame.Surface((size, size), pygame.SRCALPHA)
+        pygame.draw.circle(self.surface, (255, 50, 50), (PLAYER_RADIUS, PLAYER_RADIUS), PLAYER_RADIUS)
+
+    def move(self, dx, dy):
+        self.x = max(0, min(MAP_WIDTH - 1, self.x + dx))
+        self.y = max(0, min(MAP_HEIGHT - 1, self.y + dy))
+
+    def draw(self, screen, origin):
+        sx = (self.x - self.y) * (TILE_WIDTH // 2) + origin[0]
+        sy = (self.x + self.y) * (TILE_HEIGHT // 2) + origin[1] - PLAYER_RADIUS
+        screen.blit(self.surface, (sx, sy))
+
+
 def main():
     pygame.init()
     screen = pygame.display.set_mode((800, 600))
@@ -59,16 +80,28 @@ def main():
 
     tiles = create_tile_surfaces()
     grid = random_map()
-    renderer = TileRenderer(screen, tiles, origin=(400, 100))
+    origin = (400, 100)
+    renderer = TileRenderer(screen, tiles, origin=origin)
+    player = Player(MAP_WIDTH // 2, MAP_HEIGHT // 2)
 
     running = True
     while running:
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 running = False
+            elif event.type == pygame.KEYDOWN:
+                if event.key == pygame.K_UP:
+                    player.move(0, -1)
+                elif event.key == pygame.K_DOWN:
+                    player.move(0, 1)
+                elif event.key == pygame.K_LEFT:
+                    player.move(-1, 0)
+                elif event.key == pygame.K_RIGHT:
+                    player.move(1, 0)
 
         screen.fill((0, 0, 0))
         renderer.draw_map(grid)
+        player.draw(screen, origin)
         pygame.display.flip()
         clock.tick(60)
 

--- a/examples/tile_renderer_demo.py
+++ b/examples/tile_renderer_demo.py
@@ -113,12 +113,27 @@ class TileRenderer:
                 sy = (x + y) * (TILE_HEIGHT // 2) + self.origin_y
                 self.screen.blit(self.tiles[tile], (sx, sy))
 
-    def draw_obstacles(self, obstacles, surfaces):
+    def draw_objects(self, player, obstacles, surfaces):
+        """Draw the player together with obstacles with correct occlusion."""
+        objects = [{"x": player.x, "y": player.y, "kind": "player"}]
         for ob in obstacles:
-            surf = surfaces[ob["kind"]]
-            sx = (ob["x"] - ob["y"]) * (TILE_WIDTH // 2) + self.origin_x - surf.get_width() // 2
-            sy = (ob["x"] + ob["y"]) * (TILE_HEIGHT // 2) + self.origin_y - surf.get_height()
-            self.screen.blit(surf, (sx, sy))
+            objects.append({"x": ob["x"], "y": ob["y"], "kind": ob["kind"]})
+
+        objects.sort(key=lambda o: o["x"] + o["y"])
+
+        for obj in objects:
+            sx = (obj["x"] - obj["y"]) * (TILE_WIDTH // 2) + self.origin_x
+            sy = (obj["x"] + obj["y"]) * (TILE_HEIGHT // 2) + self.origin_y
+
+            if obj["kind"] == "player":
+                sx -= PLAYER_WIDTH // 2
+                sy -= PLAYER_HEIGHT
+                self.screen.blit(player.frames[player.frame], (sx, sy))
+            else:
+                surf = surfaces[obj["kind"]]
+                sx -= surf.get_width() // 2
+                sy -= surf.get_height()
+                self.screen.blit(surf, (sx, sy))
 
 
 class Player:
@@ -196,8 +211,7 @@ def main():
 
         screen.fill((0, 0, 0))
         renderer.draw_map(grid)
-        renderer.draw_obstacles(obstacles, obstacle_surfaces)
-        player.draw(screen, origin)
+        renderer.draw_objects(player, obstacles, obstacle_surfaces)
         pygame.display.flip()
 
     pygame.quit()


### PR DESCRIPTION
## Summary
- add `examples/tile_renderer_demo.py` showing a simple isometric tile renderer using Pygame

## Testing
- `python3 -m py_compile examples/tile_renderer_demo.py`


------
https://chatgpt.com/codex/tasks/task_e_6845dea4b0d48328bc1a957496c6a918